### PR TITLE
feat: Switch to -moz-pref, clean up formatting

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -1,101 +1,135 @@
-@-moz-document url-prefix("chrome:") {
-
-  /* These are for the popups */
-  menupopup,
-  panel {
-    &::part(content) {
-      display: flex !important;
-      box-sizing: border-box !important;
-      padding: 6px !important;
-      color: var(--panel-color) !important;
-      /*   
-      background: var(--panel-background);
-  */
-      border-radius: 15px !important;
-      border: 2px solid color-mix(in hsl, var(--panel-border-color), transparent 70%) !important;
-      width: var(--panel-width) !important;
-      box-shadow: var(--panel-shadow) !important;
-      margin: var(--panel-shadow-margin) !important;
-      min-width: 0 !important;
-      min-height: 0 !important;
-      max-height: round(up, 100% - 2 * var(--panel-shadow-margin), 1px) !important;
-      max-width: round(up, 100% - 2 * var(--panel-shadow-margin), 1px) !important;
-      overflow: clip !important;
-      scrollbar-color: transparent !important;
-    }
-  }
-
-  panel toolbarseparator {
-    appearance: none !important;
+/* These are for the popups */
+menupopup,
+panel {
+  &::part(content) {
+    display: flex !important;
+    box-sizing: border-box !important;
+    padding: 6px !important;
+    color: var(--panel-color) !important;
+    /* background: var(--panel-background); */
+    border-radius: 15px !important;
+    border: 2px solid
+      color-mix(in hsl, var(--panel-border-color), transparent 70%) !important;
+    width: var(--panel-width) !important;
+    box-shadow: var(--panel-shadow) !important;
+    margin: var(--panel-shadow-margin) !important;
+    min-width: 0 !important;
     min-height: 0 !important;
-    border-top: 3px solid color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
-    margin: 8px 4px !important;
-    padding: 0 !important;
+    max-height: round(
+      up,
+      100% - 2 * var(--panel-shadow-margin),
+      1px
+    ) !important;
+    max-width: round(up, 100% - 2 * var(--panel-shadow-margin), 1px) !important;
+    overflow: clip !important;
+    scrollbar-color: transparent !important;
   }
+}
 
-  :is(panelview .toolbarbutton-1, toolbarbutton.subviewbutton, .widget-overflow-list .toolbarbutton-1, .toolbaritem-combined-buttons:is(:not([cui-areatype="toolbar"]), [overflowedItem="true"]) > toolbarbutton) {
-    &:not([disabled]) {
-      padding: 5px 10px !important;
-      border-radius: 8px !important;
-    }
+panel toolbarseparator {
+  appearance: none !important;
+  min-height: 0 !important;
+  border-top: 3px solid
+    color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
+  margin: 8px 4px !important;
+  padding: 0 !important;
+}
+
+:is(
+  panelview .toolbarbutton-1,
+  toolbarbutton.subviewbutton,
+  .widget-overflow-list .toolbarbutton-1,
+  .toolbaritem-combined-buttons:is(
+      :not([cui-areatype="toolbar"]),
+      [overflowedItem="true"]
+    )
+    > toolbarbutton
+) {
+  &:not([disabled]) {
+    padding: 5px 10px !important;
+    border-radius: 8px !important;
   }
+}
 
-  @media (-moz-bool-pref: "mod.tidypopup.usecustomhovercolor") {
-
-    menu,
-    menuitem,
-    menucaption,
-    :is(panelview .toolbarbutton-1, toolbarbutton.subviewbutton, .widget-overflow-list .toolbarbutton-1, .toolbaritem-combined-buttons:is(:not([cui-areatype="toolbar"]), [overflowedItem="true"]) > toolbarbutton) {
-      &:not([disabled]):hover {
-        background-color: var(--mod-tidypopup-hovercolor) !important;
-      }
-    }
-  }
-
-  @media not (-moz-bool-pref: "mod.tidypopup.usecustomhovercolor") {
-
-    menu,
-    menuitem,
-    menucaption,
-    :is(panelview .toolbarbutton-1, toolbarbutton.subviewbutton, .widget-overflow-list .toolbarbutton-1, .toolbaritem-combined-buttons:is(:not([cui-areatype="toolbar"]), [overflowedItem="true"]) > toolbarbutton) {
-      &:not([disabled]):hover {
-        background-color: rgba(80, 80, 250, 1) !important;
-      }
-    }
-  }
-
-  #appMenu-zoom-controls {
-    border-top: 3px solid color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
-    padding-top: 12px !important;
-    padding-inline: calc(var(--arrowpanel-menuitem-padding-inline) + var(--uc-arrowpanel-menuitem-margin-inline)) var(--uc-arrowpanel-menuitem-margin-inline) !important;
-    padding-block: var(--uc-panel-zoom-padding-block) !important;
-    margin: var(--panel-separator-margin-vertical) 0 calc(var(--panel-separator-margin-vertical) * -1) !important;
-  }
-
-  #appMenu-zoom-controls>#appMenu-fullscreen-button2::before {
-    border-inline-start: 3px none color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
-  }
-
+@media (-moz-pref("mod.tidypopup.usecustomhovercolor")) {
   menu,
   menuitem,
-  menucaption {
-    border-radius: 8px !important;
-    margin: 2px !important;
-    border-radius: 8px !important;
+  menucaption,
+  :is(
+    panelview .toolbarbutton-1,
+    toolbarbutton.subviewbutton,
+    .widget-overflow-list .toolbarbutton-1,
+    .toolbaritem-combined-buttons:is(
+        :not([cui-areatype="toolbar"]),
+        [overflowedItem="true"]
+      )
+      > toolbarbutton
+  ) {
+    &:not([disabled]):hover {
+      background-color: var(--mod-tidypopup-hovercolor) !important;
+    }
   }
+}
 
-  menuseparator::before {
-    border-top: 3px solid color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
+@media not (-moz-pref("mod.tidypopup.usecustomhovercolor")) {
+  menu,
+  menuitem,
+  menucaption,
+  :is(
+    panelview .toolbarbutton-1,
+    toolbarbutton.subviewbutton,
+    .widget-overflow-list .toolbarbutton-1,
+    .toolbaritem-combined-buttons:is(
+        :not([cui-areatype="toolbar"]),
+        [overflowedItem="true"]
+      )
+      > toolbarbutton
+  ) {
+    &:not([disabled]):hover {
+      background-color: rgba(80, 80, 250, 1) !important;
+    }
   }
+}
 
-  .panel-view-body-unscrollable {
-    border-radius: 8px !important;
-    background: var(--button-background-color-hover) !important;
-    align-items: center !important;
-    padding: 3px !important;
-  }
+#appMenu-zoom-controls {
+  border-top: 3px solid
+    color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
+  padding-top: 12px !important;
+  padding-inline: calc(
+      var(--arrowpanel-menuitem-padding-inline) +
+        var(--uc-arrowpanel-menuitem-margin-inline)
+    )
+    var(--uc-arrowpanel-menuitem-margin-inline) !important;
+  padding-block: var(--uc-panel-zoom-padding-block) !important;
+  margin: var(--panel-separator-margin-vertical) 0
+    calc(var(--panel-separator-margin-vertical) * -1) !important;
+}
 
-  .downloadMainArea {
-    padding-left: 10px !important;
-  }
+#appMenu-zoom-controls > #appMenu-fullscreen-button2::before {
+  border-inline-start: 3px none
+    color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
+}
+
+menu,
+menuitem,
+menucaption {
+  border-radius: 8px !important;
+  margin: 2px !important;
+  border-radius: 8px !important;
+}
+
+menuseparator::before {
+  border-top: 3px solid
+    color-mix(in hsl, var(--panel-border-color), transparent 100%) !important;
+}
+
+.panel-view-body-unscrollable {
+  border-radius: 8px !important;
+  background: var(--button-background-color-hover) !important;
+  align-items: center !important;
+  padding: 3px !important;
+}
+
+.downloadMainArea {
+  padding-left: 10px !important;
 }


### PR DESCRIPTION
The latest Zen Mods documentation for [checkbox preferences](https://docs.zen-browser.app/themes-store/themes-marketplace-preferences#checkbox-preferences) recommends using ```-moz-pref``` over ```-moz-bool-pref``` as the former is now natively implemented into Firefox and will be maintained, unlike the latter which was implemented by Zen exclusively and will not work anywhere else.

I also just cleaned up some of the CSS formatting while I was at it and verified that all the changes worked properly before creating this pull request.

Thanks! :)